### PR TITLE
Feature | allow python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
         os:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
         os:
           - ubuntu-latest
           - macos-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ sdist-include = [
 
 [tool.poetry]
 name = "pyrepscan"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Gal Ben David <gal@intsights.com>"]
 description = "A Git Repository Secrets Scanner written in Rust"
 readme = "README.md"


### PR DESCRIPTION
Allow python 3.11 in PyRepScan